### PR TITLE
Nerfing the bluespace miner

### DIFF
--- a/modular_sand/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/modular_sand/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -40,7 +40,7 @@
 		/obj/item/stock_parts/micro_laser = 5,
 		/obj/item/stock_parts/manipulator = 5,
 		/obj/item/stock_parts/scanning_module = 5,
-		/obj/item/stack/ore/bluespace_crystal = 5)
+		/obj/item/stack/ore/bluespace_crystal = 10)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/telecomms/message_server

--- a/modular_sand/code/modules/mining/machine_bluespaceminer.dm
+++ b/modular_sand/code/modules/mining/machine_bluespaceminer.dm
@@ -7,7 +7,7 @@
 	can_be_unanchored = TRUE
 	circuit = /obj/item/circuitboard/machine/bluespace_miner
 	layer = BELOW_OBJ_LAYER
-	var/list/ore_rates = list(/datum/material/iron = 0.3, /datum/material/glass = 0.3, /datum/material/plasma = 0.1,  /datum/material/silver = 0.1, /datum/material/gold = 0.05, /datum/material/titanium = 0.05, /datum/material/uranium = 0.05, /datum/material/diamond = 0.02)
+	var/list/ore_rates = list(/datum/material/iron = 0.15, /datum/material/glass = 0.15, /datum/material/plasma = 0.05,  /datum/material/silver = 0.05, /datum/material/gold = 0.025, /datum/material/titanium = 0.025, /datum/material/uranium = 0.025, /datum/material/diamond = 0.01)
 	var/datum/component/remote_materials/materials
 	var/multiplier = 0 //Multiplier by tier, has been made fair and everything
 

--- a/modular_sand/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/modular_sand/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -36,7 +36,7 @@
 	description = "Harness the power of bluespace to make materials out of nothing. Slowly."
 	prereq_ids = list("practical_bluespace", "adv_mining")
 	design_ids = list("bluespace_miner")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000) //Increased price due to being top-tier tech in the reality.
 
 /datum/techweb_node/shuttle_route_upgrade_hyper/New()
 	design_ids += "disk_shuttle_smoothsail"


### PR DESCRIPTION

# Reducing the bluespace miner efficiency.
## Why It's Good For The Game
Shaft miners now have a reason to exist

## A Port?

No.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog

:cl:
balance: Bluespace miner requires 10 crystals instead of 5.
balance: Bluespace miner now is a high-tier tech, requiring 20K points instead of 7.5K.
balance: Bluespace miner now produces 50% less resources.
/:cl:
